### PR TITLE
Add HTML highlighting support for .aspx files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1 - ASPX file type support
+* Adds HTML highlighting support for `.aspx` file types
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/grammars/html-asp.cson
+++ b/grammars/html-asp.cson
@@ -1,5 +1,5 @@
 'fileTypes': [
-  'asp'
+  'asp', 'aspx'
 ]
 'name': 'HTML (ASP)'
 'patterns': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-asp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Classic ASP language support",
   "repository": "https://github.com/Trickierstinky/language-asp",
   "license": "MIT",


### PR DESCRIPTION
I'm frequently working on `.aspx` files as a front-end developer.

Version numbers updated.